### PR TITLE
Fix Zemberek invocation

### DIFF
--- a/zemberek_bridge.py
+++ b/zemberek_bridge.py
@@ -7,13 +7,12 @@ def analyze_with_zemberek(word):
     print(f"Zemberek testi: '{word}'")
     try:
         result = subprocess.run(
-            ["java", "-cp", JAR_PATH, MAIN_CLASS, word],
+            ["java", "-cp", JAR_PATH, MAIN_CLASS],
             capture_output=True,
-            text=True
+            text=True,
+            input=f"{word}\nquit\n"
         )
         print(result.stdout.strip())
-        if result.stderr:
-            print("⚠️ Hata:", result.stderr.strip())
     except Exception as e:
         print("🚨 Çalıştırma hatası:", e)
 


### PR DESCRIPTION
## Summary
- fix MorphologyConsole invocation to use stdin
- remove printing of stderr logs

## Testing
- `python zemberek_bridge.py | head`
- `python -m py_compile zemberek_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_6856b829ea10832ca90fdcc7a73ddac8