### PR TITLE
Ensure UTF-8 encoding for Zemberek bridge

### DIFF
--- a/zemberek_bridge.py
+++ b/zemberek_bridge.py
@@ -7,10 +7,17 @@ def analyze_with_zemberek(word):
     print(f"Zemberek testi: '{word}'")
     try:
         result = subprocess.run(
-            ["java", "-cp", JAR_PATH, MAIN_CLASS],
+            [
+                "java",
+                "-Dfile.encoding=UTF-8",
+                "-cp",
+                JAR_PATH,
+                MAIN_CLASS,
+            ],
             capture_output=True,
             text=True,
-            input=f"{word}\nquit\n"
+            encoding="utf-8",
+            input=f"{word}\nquit\n",
         )
         print(result.stdout.strip())
     except Exception as e:


### PR DESCRIPTION
## Summary
- call Java with `-Dfile.encoding=UTF-8` and pass `encoding="utf-8"` to `subprocess.run`
- verify script prints proper morphological analysis

## Testing
- `python zemberek_bridge.py | head -n 6`

------
https://chatgpt.com/codex/tasks/task_e_6856c6bb8580832c9f1c7dabdac1d230