### PR TITLE
Add CLI word option to zemberek_bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ The bot communicates in Turkish. Type `çık` (or `exit`/`quit`) to end the sess
 
 ### Zemberek Morphological Analysis
 
-To try a simple Zemberek integration, use `zemberek_bridge.py`:
+To try a simple Zemberek integration, run `zemberek_bridge.py` and pass the word
+to analyze using the `--word` argument:
 
 ```bash
-python zemberek_bridge.py
+python zemberek_bridge.py --word kelime
 ```
 
-The script invokes the included `zemberek-full.jar` to analyze a sample word and prints the result. You can modify `zemberek_bridge.py` to analyze any word you like.
+If no word is provided, the script analyzes the default example word
+`geliyormuşsunuz`.
+
+The script invokes the included `zemberek-full.jar` to analyze the word and prints the result. You can modify `zemberek_bridge.py` to analyze any word you like.
 
 ## Project Purpose
 

--- a/zemberek_bridge.py
+++ b/zemberek_bridge.py
@@ -1,11 +1,17 @@
 import os
 import subprocess
+import argparse
+import sys
 
 JAR_PATH = os.path.join(os.path.dirname(__file__), "zemberek-full.jar")
 MAIN_CLASS = "zemberek.apps.morphology.MorphologyConsole"
+DEFAULT_WORD = "geliyormuşsunuz"
 
 def analyze_with_zemberek(word):
     print(f"Zemberek testi: '{word}'")
+    if not os.path.exists(JAR_PATH):
+        print(f"🚨 Zemberek jar not found: {JAR_PATH}")
+        sys.exit(1)
     try:
         result = subprocess.run(
             [
@@ -38,4 +44,15 @@ def analyze_with_zemberek(word):
         print("🚨 Çalıştırma hatası:", e)
 
 if __name__ == "__main__":
-    analyze_with_zemberek("geliyormuşsunuz")
+    parser = argparse.ArgumentParser(
+        description="Run morphological analysis using Zemberek"
+    )
+    parser.add_argument(
+        "--word",
+        "-w",
+        default=DEFAULT_WORD,
+        help="Word to analyze",
+    )
+    args = parser.parse_args()
+
+    analyze_with_zemberek(args.word)


### PR DESCRIPTION
## Summary
- allow specifying the word for analysis via `--word`
- exit with a helpful message if `zemberek-full.jar` is missing
- document new usage example in README

## Testing
- `python -m py_compile zemberek_bridge.py chat.py groq_api.py class_check.py`


------
https://chatgpt.com/codex/tasks/task_e_6856d8c5ad24832cb216ed489cbd7bf5