### PR TITLE
Add Zemberek spell correction integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # GroqChat
 
-GroqChat is a simple command-line chat application that uses the Groq API. It can optionally integrate with the Turkish NLP library Zemberek to demonstrate morphological analysis.
+GroqChat is a simple command-line chat application that uses the Groq API. It can optionally integrate with the Turkish NLP library Zemberek to demonstrate morphological analysis and spell correction.
 
 ## Prerequisites
 
 - **Python 3**
-- **Java** (required only for Zemberek)
+- **Java (JDK)** – required for Zemberek spell checking
 - Obtain your `GROQ_API_KEY` and create a `.env` file in the project root containing:
 
   ```
@@ -30,6 +30,13 @@ python chat.py
 ```
 
 The bot communicates in Turkish. Type `çık` (or `exit`/`quit`) to end the session.
+
+### Spell Correction with Zemberek
+
+When `zemberek-full.jar` is available, `chat.py` automatically sends every
+message through Zemberek's `TurkishSpellChecker`. Both your input and the model
+reply are corrected before being added to the chat history. Ensure that `java`
+and `javac` are installed and that the JAR is located in the project root.
 
 ### Zemberek Morphological Analysis
 

--- a/chat.py
+++ b/chat.py
@@ -1,4 +1,5 @@
 from groq_api import send_message
+from zemberek_bridge import correct_text
 
 def main():
     print("🤖 GroqChat'e hoş geldiniz! (Çıkmak için 'çık' yazın)\n")
@@ -15,16 +16,18 @@ def main():
             print("🔚 Sohbet sonlandırıldı. Görüşmek üzere!")
             break
 
+        corrected_user = correct_text(user_input)
+
         # Yeni kullanıcı mesajını geçmişe ekle
-        chat_history.append({"role": "user", "content": user_input})
+        chat_history.append({"role": "user", "content": corrected_user})
 
         # API'den yanıt al
         reply = send_message(chat_history)
+        corrected_reply = correct_text(reply)
 
         # Model cevabını geçmişe ekle
-        chat_history.append({"role": "assistant", "content": reply})
-
-        print(f"🤖 Bot: {reply}\n")
+        chat_history.append({"role": "assistant", "content": corrected_reply})
+        print(f"🤖 Bot: {corrected_reply}\n")
 
 if __name__ == "__main__":
     main()

--- a/zemberek_bridge.py
+++ b/zemberek_bridge.py
@@ -2,10 +2,71 @@ import os
 import subprocess
 import argparse
 import sys
+import tempfile
+from pathlib import Path
 
 JAR_PATH = os.path.join(os.path.dirname(__file__), "zemberek-full.jar")
 MAIN_CLASS = "zemberek.apps.morphology.MorphologyConsole"
 DEFAULT_WORD = "geliyormuşsunuz"
+
+SPELL_CORRECT_JAVA = """
+import zemberek.morphology.TurkishMorphology;
+import zemberek.normalization.TurkishSpellChecker;
+
+public class SpellCorrect {
+    public static void main(String[] args) throws Exception {
+        TurkishMorphology morphology = TurkishMorphology.createWithDefaults();
+        TurkishSpellChecker sc = new TurkishSpellChecker(morphology);
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < args.length; i++) {
+            String tok = args[i];
+            if (!sc.check(tok)) {
+                java.util.List<String> sug = sc.suggestForWord(tok);
+                if (!sug.isEmpty()) {
+                    tok = sug.get(0);
+                }
+            }
+            out.append(tok);
+            if (i < args.length - 1) out.append(' ');
+        }
+        System.out.println(out.toString());
+    }
+}
+"""
+
+def correct_text(text: str) -> str:
+    """Return spell-corrected text using Zemberek if available."""
+    if not os.path.exists(JAR_PATH):
+        return text
+
+    words = text.split()
+    if not words:
+        return text
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        java_file = Path(tmpdir) / "SpellCorrect.java"
+        class_file = Path(tmpdir) / "SpellCorrect.class"
+        java_file.write_text(SPELL_CORRECT_JAVA, encoding="utf-8")
+
+        compile_cmd = ["javac", "-cp", JAR_PATH, str(java_file)]
+        try:
+            subprocess.run(compile_cmd, capture_output=True, check=True)
+        except Exception:
+            return text
+
+        run_cmd = [
+            "java",
+            "-cp",
+            f"{tmpdir}:{JAR_PATH}",
+            "SpellCorrect",
+            *words,
+        ]
+        try:
+            result = subprocess.run(run_cmd, capture_output=True, check=True)
+            corrected = result.stdout.decode("utf-8").strip()
+            return corrected if corrected else text
+        except Exception:
+            return text
 
 def analyze_with_zemberek(word):
     print(f"Zemberek testi: '{word}'")


### PR DESCRIPTION
## Summary
- add `correct_text` in `zemberek_bridge.py` that uses `TurkishSpellChecker`
- integrate spell correction into `chat.py`
- document spell checker usage and Java requirement

## Testing
- `python -m py_compile chat.py zemberek_bridge.py groq_api.py class_check.py`
- `python chat.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6856e650865c832c8fd40570a113215f