### PR TITLE
Add limitations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ GroqChat provides a simple command-line interface for interacting with the Groq 
 
 Install dependencies using `pip install -r requirements.txt`.
 
+### Limitations
+
+- The assistant cannot browse the web or verify live data. All responses come
+  from the underlying language model without external retrieval.
+- Answers may be outdated or incorrect, so you should verify important
+  information independently.
+- The default `temperature` in `groq_api.py` is set to `0.7`, which encourages
+  cautious replies and aims to reduce speculation.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document that GroqChat cannot browse the web and may be outdated
- clarify that responses use a low temperature value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fa73c01c832c8428ae575067c021