### PR TITLE
Fix README temperature mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Install dependencies using `pip install -r requirements.txt`.
   from the underlying language model without external retrieval.
 - Answers may be outdated or incorrect, so you should verify important
   information independently.
-- The default `temperature` in `groq_api.py` is set to `0.7`, which encourages
-  cautious replies and aims to reduce speculation.
+- The default `temperature` in `groq_api.py` is set to `0.3`, yielding more
+  deterministic replies with minimal creative variation.
 
 ## License
 


### PR DESCRIPTION
## Summary
- update the temperature setting in the limitations section of the README

## Testing
- `python -m py_compile chat.py groq_api.py class_check.py zemberek_bridge.py`

------
https://chatgpt.com/codex/tasks/task_e_6856fea2a994832ca0aa7f38872e8aae