### PR TITLE
Fix SpellCorrect encoding on Windows

### DIFF
--- a/zemberek_bridge.py
+++ b/zemberek_bridge.py
@@ -78,6 +78,7 @@ def correct_text(text: str) -> str:
         classpath = os.pathsep.join([str(tmpdir), JAR_PATH])
         run_cmd = [
             "java",
+            "-Dfile.encoding=UTF-8",
             "-cp",
             classpath,
             "SpellCorrect",


### PR DESCRIPTION
## Summary
- ensure SpellCorrect Java process outputs UTF-8

## Testing
- `python -m py_compile chat.py groq_api.py zemberek_bridge.py`

------
https://chatgpt.com/codex/tasks/task_e_68570708b1b4832ca6a4b02e49f1c387