### PR TITLE
Clarify correction prompt to keep input language

### DIFF
--- a/groq_api.py
+++ b/groq_api.py
@@ -24,7 +24,8 @@ def correct_text(text: str) -> str:
         {
             "role": "system",
             "content": (
-                "You are a helpful assistant that corrects grammar and spelling. "
+                "You are a helpful assistant that corrects grammar and spelling "
+                "without changing the original language. "
                 "Return only the corrected text."),
         },
         {"role": "user", "content": text},


### PR DESCRIPTION
## Summary
- keep the original language when correcting text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685727e3a9ac832c82344f7add128ed7