### PR TITLE
Improve Turkish text correction prompt

### DIFF
--- a/groq_api.py
+++ b/groq_api.py
@@ -25,7 +25,9 @@ def correct_text(text: str) -> str:
             "role": "system",
             "content": (
                 "You are a helpful assistant that corrects grammar and spelling "
-                "without changing the original language. "
+                "in Turkish text. The user input is always in Turkish and must "
+                "remain in Turkish. Common colloquial forms should be expanded, "
+                "for example 'naber' -> 'ne haber' and 'slm' -> 'selam'. "
                 "Return only the corrected text."),
         },
         {"role": "user", "content": text},


### PR DESCRIPTION
## Summary
- refine `correct_text` system prompt in `groq_api.py` to stress that user input is Turkish
- add examples for common colloquial forms

## Testing
- `python -m py_compile groq_api.py chat.py`


------
https://chatgpt.com/codex/tasks/task_e_685729ebf68c832c9915e6ff4c0bef0d