### PR TITLE
Update README to describe prompt customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The bot communicates in Turkish. Type `çık` (or `exit`/`quit`) to end the sess
 
 GroqChat provides a minimal command-line interface for interacting with the Groq API. The helper module `groq_api.py` reads `GROQ_API_KEY` from a `.env` file and can be modified to call the OpenAI API or even a local model by adjusting the endpoint and headers. The example script `chat.py` demonstrates a basic Turkish conversation assistant.
 
+The correction behavior is defined in `groq_api.py` inside the `correct_text` function. The system prompt there expands slang words to their full forms. Changing this prompt alters how text is cleaned. For instance, instructing it to keep slang would return `slm naber` instead of the default `selam ne haber`.
+
 ## Requirements
 
 Install dependencies using `pip install -r requirements.txt`.


### PR DESCRIPTION
## Summary
- document that text correction rules live in `groq_api.py` under `correct_text`
- add a note on how changing the system prompt can keep slang

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68572b516b9c832c95c3d2fdb7c33d1a