### PR TITLE
Update model path for inference

### DIFF
--- a/inference/configs/sequence_tagger/test.yaml
+++ b/inference/configs/sequence_tagger/test.yaml
@@ -2,7 +2,7 @@ test_dataset_dir: datasets/gec_tr/gec_tr_source_annot_val.txt
 experiment_name: "experiments"
 
 model:
-  model_name: weights/sequence-tagger
+  model_name: weights/mGPT
   tokenizer: dbmdz/bert-base-turkish-cased
   num_labels: 26
 


### PR DESCRIPTION
## Summary
- configure sequence tagger to load model from `weights/mGPT`

## Testing
- `python -m py_compile chat.py groq_api.py inference/*.py`
- `python inference/test.py --help` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68586db45a80832ca6a126a2a229ce79