### PR TITLE
Add missing inference deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
 python-dotenv
 requests
 gdown
+
+transformers
+torch
+tqdm
+numpy
+omegaconf
+datasets


### PR DESCRIPTION
## Summary
- list dependencies needed for `inference/test.py` and `inference/train.py`

## Testing
- `nl -ba requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68586fd2bca8832c9b8ad4ed90062fb0